### PR TITLE
Making content type resolution more robust

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,9 +40,9 @@ subprojects {
 
     ext {
         graphqlJavaVersion = "12.0"
-        springVersion = "5.1.2.RELEASE"
-        springBootVersion = "2.1.0.RELEASE"
-        jacksonVersion = "2.9.6"
+        springVersion = "5.1.7.RELEASE"
+        springBootVersion = "2.1.5.RELEASE"
+        jacksonVersion = "2.9.8"
         assertJVersion = "3.11.1"
     }
 

--- a/graphql-java-spring-webflux/src/main/java/graphql/spring/web/reactive/components/GraphQLController.java
+++ b/graphql-java-spring-webflux/src/main/java/graphql/spring/web/reactive/components/GraphQLController.java
@@ -9,7 +9,9 @@ import graphql.spring.web.reactive.JsonSerializer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.InvalidMediaTypeException;
 import org.springframework.http.MediaType;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,6 +28,9 @@ import java.util.Map;
 @RestController
 @Internal
 public class GraphQLController {
+
+    static String APPLICATION_GRAPHQL_VALUE = "application/graphql";
+    static MediaType APPLICATION_GRAPHQL = MediaType.parseMediaType(APPLICATION_GRAPHQL_VALUE);
 
     @Autowired
     GraphQLInvocation graphQLInvocation;
@@ -47,6 +52,14 @@ public class GraphQLController {
             @RequestBody(required = false) String body,
             ServerWebExchange serverWebExchange) {
 
+        MediaType mediaType = null;
+        if (!StringUtils.isEmpty(contentType)) {
+            try {
+                mediaType = MediaType.parseMediaType(contentType);
+            } catch (InvalidMediaTypeException ignore) {
+            }
+        }
+
         if (body == null) {
             body = "";
         }
@@ -62,7 +75,7 @@ public class GraphQLController {
         //   "variables": { "myVariable": "someValue", ... }
         // }
 
-        if (MediaType.APPLICATION_JSON_VALUE.equals(contentType)) {
+        if (MediaType.APPLICATION_JSON.equalsTypeAndSubtype(mediaType)) {
             GraphQLRequestBody request = jsonSerializer.deserialize(body, GraphQLRequestBody.class);
             if (request.getQuery() == null) {
                 request.setQuery("");
@@ -82,7 +95,7 @@ public class GraphQLController {
         // * If the "application/graphql" Content-Type header is present,
         //   treat the HTTP POST body contents as the GraphQL query string.
 
-        if ("application/graphql".equals(contentType)) {
+        if (APPLICATION_GRAPHQL.equalsTypeAndSubtype(mediaType)) {
             return executeRequest(body, null, null, serverWebExchange);
         }
 

--- a/graphql-java-spring-webflux/src/test/java/graphql/spring/web/reactive/components/GraphQLControllerTest.java
+++ b/graphql-java-spring-webflux/src/test/java/graphql/spring/web/reactive/components/GraphQLControllerTest.java
@@ -18,7 +18,6 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Mono;
 import testconfig.TestAppConfig;
 
-import java.net.URLEncoder;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -109,9 +108,7 @@ public class GraphQLControllerTest {
     @Test
     public void testQueryParamPostRequest() throws Exception {
         String variablesJson = "{\"variable\":\"variableValue\"}";
-        String variablesValue = URLEncoder.encode(variablesJson, "UTF-8");
         String query = "query myQuery {foo}";
-        String queryString = URLEncoder.encode(query, "UTF-8");
         String operationName = "myQuery";
 
         ExecutionResultImpl executionResult = ExecutionResultImpl.newExecutionResult()
@@ -122,10 +119,10 @@ public class GraphQLControllerTest {
         Mockito.when(graphql.executeAsync(captor.capture())).thenReturn(cf);
 
         client.post().uri(uriBuilder -> uriBuilder.path("/graphql")
-                .queryParam("variables", variablesValue)
-                .queryParam("query", queryString)
-                .queryParam("operationName", operationName)
-                .build(variablesJson, queryString))
+                .queryParam("variables", "{variables}")
+                .queryParam("query", "{query}")
+                .queryParam("operationName", "{operationName}")
+                .build(variablesJson, query, operationName))
                 .accept(MediaType.APPLICATION_JSON_UTF8)
                 .exchange()
                 .expectStatus().isOk()
@@ -144,7 +141,6 @@ public class GraphQLControllerTest {
     @Test
     public void testSimpleQueryParamPostRequest() throws Exception {
         String query = "{foo}";
-        String queryString = URLEncoder.encode(query, "UTF-8");
 
         ExecutionResultImpl executionResult = ExecutionResultImpl.newExecutionResult()
                 .data("bar")
@@ -154,8 +150,8 @@ public class GraphQLControllerTest {
         Mockito.when(graphql.executeAsync(captor.capture())).thenReturn(cf);
 
         client.post().uri(uriBuilder -> uriBuilder.path("/graphql")
-                .queryParam("query", queryString)
-                .build())
+                .queryParam("query", "{query}")
+                .build(query))
                 .accept(MediaType.APPLICATION_JSON_UTF8)
                 .exchange()
                 .expectStatus().isOk()
@@ -196,9 +192,7 @@ public class GraphQLControllerTest {
     @Test
     public void testGetRequest() throws Exception {
         String variablesJson = "{\"variable\":\"variableValue\"}";
-        String variablesValue = URLEncoder.encode(variablesJson, "UTF-8");
         String query = "query myQuery {foo}";
-        String queryString = URLEncoder.encode(query, "UTF-8");
         String operationName = "myQuery";
 
         ExecutionResultImpl executionResult = ExecutionResultImpl.newExecutionResult()
@@ -209,10 +203,10 @@ public class GraphQLControllerTest {
         Mockito.when(graphql.executeAsync(captor.capture())).thenReturn(cf);
 
         client.get().uri(uriBuilder -> uriBuilder.path("/graphql")
-                .queryParam("variables", variablesValue)
-                .queryParam("query", queryString)
-                .queryParam("operationName", operationName)
-                .build(variablesJson, queryString))
+                .queryParam("variables", "{variables}")
+                .queryParam("query", "{query}")
+                .queryParam("operationName", "{operationName}")
+                .build(variablesJson, query, operationName))
                 .accept(MediaType.APPLICATION_JSON_UTF8)
                 .exchange()
                 .expectStatus().isOk()
@@ -231,7 +225,6 @@ public class GraphQLControllerTest {
     @Test
     public void testSimpleGetRequest() throws Exception {
         String query = "{foo}";
-        String queryString = URLEncoder.encode(query, "UTF-8");
 
         ExecutionResultImpl executionResult = ExecutionResultImpl.newExecutionResult()
                 .data("bar")
@@ -241,8 +234,8 @@ public class GraphQLControllerTest {
         Mockito.when(graphql.executeAsync(captor.capture())).thenReturn(cf);
 
         client.get().uri(uriBuilder -> uriBuilder.path("/graphql")
-                .queryParam("query", queryString)
-                .build())
+                .queryParam("query", "{query}")
+                .build(query))
                 .accept(MediaType.APPLICATION_JSON_UTF8)
                 .exchange()
                 .expectStatus().isOk()


### PR DESCRIPTION
Similar as https://github.com/micronaut-projects/micronaut-graphql/issues/7 this makes the content type resolution more robust. E.g. case insensitive and ignoring content type parameters.

To do so I upgraded the Spring Boot + Spring minor versions to use [equalsTypeAndSubtype](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/util/MimeType.html#equalsTypeAndSubtype-org.springframework.util.MimeType-) introduced in Spring 5.1.4.

This also caused I had to change some integration tests using `WebTestClient` because of a [bug](https://github.com/spring-projects/spring-framework/issues/21997) in 5.1.2 which resulted in different behaviour.
