### PR TITLE
Make content type checking less strict

### DIFF
--- a/graphql-java-spring-webflux/src/main/java/graphql/spring/web/reactive/components/GraphQLController.java
+++ b/graphql-java-spring-webflux/src/main/java/graphql/spring/web/reactive/components/GraphQLController.java
@@ -62,7 +62,7 @@ public class GraphQLController {
         //   "variables": { "myVariable": "someValue", ... }
         // }
 
-        if (MediaType.APPLICATION_JSON_VALUE.equals(contentType)) {
+        if (contentType != null && contentType.startsWith(MediaType.APPLICATION_JSON_VALUE)) {
             GraphQLRequestBody request = jsonSerializer.deserialize(body, GraphQLRequestBody.class);
             if (request.getQuery() == null) {
                 request.setQuery("");

--- a/graphql-java-spring-webflux/src/test/java/graphql/spring/web/reactive/components/GraphQLControllerTest.java
+++ b/graphql-java-spring-webflux/src/test/java/graphql/spring/web/reactive/components/GraphQLControllerTest.java
@@ -64,7 +64,7 @@ public class GraphQLControllerTest {
         Mockito.when(graphql.executeAsync(captor.capture())).thenReturn(cf);
 
         client.post().uri("/graphql")
-                .contentType(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .body(Mono.just(request), Map.class)
                 .accept(MediaType.APPLICATION_JSON_UTF8)
                 .exchange()
@@ -93,7 +93,7 @@ public class GraphQLControllerTest {
         Mockito.when(graphql.executeAsync(captor.capture())).thenReturn(cf);
 
         client.post().uri("/graphql")
-                .contentType(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .body(Mono.just(request), Map.class)
                 .accept(MediaType.APPLICATION_JSON_UTF8)
                 .exchange()

--- a/graphql-java-spring-webmvc/src/main/java/graphql/spring/web/servlet/components/GraphQLController.java
+++ b/graphql-java-spring-webmvc/src/main/java/graphql/spring/web/servlet/components/GraphQLController.java
@@ -63,7 +63,7 @@ public class GraphQLController {
         //   "variables": { "myVariable": "someValue", ... }
         // }
 
-        if (MediaType.APPLICATION_JSON_VALUE.equals(contentType)) {
+        if (contentType != null && contentType.startsWith(MediaType.APPLICATION_JSON_VALUE)) {
             GraphQLRequestBody request = jsonSerializer.deserialize(body, GraphQLRequestBody.class);
             if (request.getQuery() == null) {
                 request.setQuery("");

--- a/graphql-java-spring-webmvc/src/test/java/graphql/spring/web/servlet/components/GraphQLControllerTest.java
+++ b/graphql-java-spring-webmvc/src/test/java/graphql/spring/web/servlet/components/GraphQLControllerTest.java
@@ -86,7 +86,7 @@ public class GraphQLControllerTest {
 
         MvcResult mvcResult = this.mockMvc.perform(post("/graphql")
                 .content(toJson(request))
-                .contentType(MediaType.APPLICATION_JSON))
+                .contentType(MediaType.APPLICATION_JSON_UTF8))
                 .andExpect(status().isOk())
                 .andExpect(request().asyncStarted())
                 .andReturn();
@@ -121,7 +121,7 @@ public class GraphQLControllerTest {
 
         MvcResult mvcResult = this.mockMvc.perform(post("/graphql")
                 .content(toJson(request))
-                .contentType(MediaType.APPLICATION_JSON))
+                .contentType(MediaType.APPLICATION_JSON_UTF8))
                 .andExpect(status().isOk())
                 .andExpect(request().asyncStarted())
                 .andReturn();


### PR DESCRIPTION
Thanks for making `graphql-java-spring` 👍

I've run into an issue when a doing a query with a content-type of `application/json;charset=UTF-8`.  The GraphQLController rejects the request because strict matching does not like the `;charset=UTF-8` on the end

This PR updates both controllers to be less strict when checking the incoming content type.