### PR TITLE
Add graphql subscription support

### DIFF
--- a/graphql-java-spring-boot-starter-webflux/src/main/java/graphql/spring/web/reactive/subscription/EnableGraphqlSubscriptionEndpoint.java
+++ b/graphql-java-spring-boot-starter-webflux/src/main/java/graphql/spring/web/reactive/subscription/EnableGraphqlSubscriptionEndpoint.java
@@ -1,0 +1,26 @@
+package graphql.spring.web.reactive.subscription;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.context.annotation.Import;
+import org.springframework.web.reactive.config.DelegatingWebFluxConfiguration;
+import org.springframework.web.reactive.config.WebFluxConfigurationSupport;
+import org.springframework.web.reactive.config.WebFluxConfigurer;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Adding this annotation to an {@code @Configuration} class enable the graphql endpoint
+ * that will serve a subscripiton request coming into /subscription. Someone can override it
+ * by specifying `graphql.subscription.url` property.
+ *
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Documented
+@Import(GraphQLWebSocketEndpointConfiguration.class)
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)
+public @interface EnableGraphqlSubscriptionEndpoint { }

--- a/graphql-java-spring-boot-starter-webflux/src/test/java/graphql/spring/web/reactive/subscription/GraphQLSubscriptionAppConfig.java
+++ b/graphql-java-spring-boot-starter-webflux/src/test/java/graphql/spring/web/reactive/subscription/GraphQLSubscriptionAppConfig.java
@@ -1,0 +1,42 @@
+package graphql.spring.web.reactive.subscription;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import graphql.GraphQL;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaGenerator;
+import graphql.schema.idl.SchemaParser;
+import org.springframework.context.annotation.Bean;
+import reactor.core.publisher.Flux;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+
+import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring;
+
+@EnableGraphqlSubscriptionEndpoint
+public class GraphQLSubscriptionAppConfig {
+
+    @Bean
+    GraphQL graphQL() {
+        Reader streamReader = loadSchemaFile("hello.graphqls");
+        RuntimeWiring wiring = RuntimeWiring
+                .newRuntimeWiring()
+                .type(newTypeWiring("Subscription")
+                        .dataFetcher("hello", environment -> Flux.just("world").repeat()))
+                .build();
+        GraphQLSchema graphQLSchema = new SchemaGenerator().makeExecutableSchema(new SchemaParser().parse(streamReader), wiring);
+        return GraphQL.newGraphQL(graphQLSchema).build();
+    }
+
+    private Reader loadSchemaFile(String name) {
+        InputStream stream = getClass().getClassLoader().getResourceAsStream(name);
+        return new InputStreamReader(stream);
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/graphql-java-spring-boot-starter-webflux/src/test/java/graphql/spring/web/reactive/subscription/GraphQLSubscriptionControllerTest.java
+++ b/graphql-java-spring-boot-starter-webflux/src/test/java/graphql/spring/web/reactive/subscription/GraphQLSubscriptionControllerTest.java
@@ -1,0 +1,63 @@
+package graphql.spring.web.reactive.subscription;
+
+import graphql.GraphQL;
+import graphql.spring.web.reactive.IntegrationTestConfig;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.reactive.socket.WebSocketMessage;
+import org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient;
+import org.springframework.web.reactive.socket.client.WebSocketClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.Assert.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = "spring.main.allow-bean-definition-overriding=true",
+        classes = IntegrationTestConfig.class)
+@ContextConfiguration(classes = GraphQLSubscriptionAppConfig.class)
+public class GraphQLSubscriptionControllerTest {
+
+    @Autowired
+    GraphQL graphql;
+
+    @LocalServerPort
+    int port;
+
+    @Test
+    public void testSubscriptionRequest() {
+        String query = "" +
+                "    subscription HelloSubscription {\n" +
+                "        hello\n" +
+                "    }\n";
+        WebSocketClient client = new ReactorNettyWebSocketClient();
+        URI localWebSocketAddr = URI.create("ws://localhost:" + port + "/subscription");
+        AtomicInteger counter = new AtomicInteger(0);
+        client.execute(localWebSocketAddr, session -> {
+            Flux<Void> receive = session
+                    .receive()
+                    .map(WebSocketMessage::getPayloadAsText)
+                    .doOnNext(text -> counter.incrementAndGet())
+                    .bufferTimeout(5, Duration.ofSeconds(3))
+                    .flatMap(list -> session.close());
+            return session
+                    .send(Mono.just(session.textMessage(query)))
+                    .thenMany(receive)
+                    .then();
+        }).block(Duration.ofSeconds(10));
+        assertThat(counter.intValue(), greaterThanOrEqualTo(5));
+    }
+}

--- a/graphql-java-spring-boot-starter-webflux/src/test/resources/hello.graphqls
+++ b/graphql-java-spring-boot-starter-webflux/src/test/resources/hello.graphqls
@@ -1,0 +1,15 @@
+
+# Schemas must have at least a query root type
+#
+schema {
+    query: Query
+    subscription : Subscription
+}
+
+type Query {
+    helo : String
+}
+
+type Subscription {
+    hello : String
+}

--- a/graphql-java-spring-webflux/src/main/java/graphql/spring/web/reactive/GraphQLSubscriptionInvocation.java
+++ b/graphql-java-spring-webflux/src/main/java/graphql/spring/web/reactive/GraphQLSubscriptionInvocation.java
@@ -1,0 +1,15 @@
+package graphql.spring.web.reactive;
+
+import graphql.PublicApi;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Flux;
+
+import java.util.Map;
+
+@PublicApi
+@FunctionalInterface
+public interface GraphQLSubscriptionInvocation {
+
+    Flux<Map<String, Object>> invoke(GraphQLInvocationData invocationData, ServerWebExchange serverWebExchange);
+
+}

--- a/graphql-java-spring-webflux/src/main/java/graphql/spring/web/reactive/subscription/DefaultGraphQLSubscriptionInvocation.java
+++ b/graphql-java-spring-webflux/src/main/java/graphql/spring/web/reactive/subscription/DefaultGraphQLSubscriptionInvocation.java
@@ -1,0 +1,53 @@
+package graphql.spring.web.reactive.subscription;
+
+import graphql.ExecutionInput;
+import graphql.ExecutionResult;
+import graphql.GraphQL;
+import graphql.Internal;
+import graphql.spring.web.reactive.ExecutionInputCustomizer;
+import graphql.spring.web.reactive.GraphQLInvocationData;
+import graphql.spring.web.reactive.GraphQLSubscriptionInvocation;
+import org.dataloader.DataLoaderRegistry;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Flux;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Internal
+@Component
+public class DefaultGraphQLSubscriptionInvocation implements GraphQLSubscriptionInvocation {
+
+    @Autowired
+    private GraphQL graphQL;
+
+    @Autowired
+    private Optional<DataLoaderRegistry> optionalDataLoaderRegistry;
+
+    @Autowired
+    private ExecutionInputCustomizer executionInputCustomizer;
+
+    @Override
+    public Flux<Map<String, Object>> invoke(GraphQLInvocationData invocationData, ServerWebExchange serverWebExchange) {
+        ExecutionInput.Builder executionInputBuilder = ExecutionInput
+                .newExecutionInput()
+                .query(invocationData.getQuery())
+                .operationName(invocationData.getOperationName())
+                .variables(invocationData.getVariables());
+        optionalDataLoaderRegistry.ifPresent(executionInputBuilder::dataLoaderRegistry);
+        return executionInputCustomizer
+                .customizeExecutionInput(executionInputBuilder.build(), serverWebExchange)
+                .map(graphQL::execute)
+                .flatMapMany(executionResult -> {
+                    if (executionResult.isDataPresent()) {
+                        return Flux.from(executionResult.getData());
+                    } else {
+                        return Flux.empty();
+                    }
+                })
+                .cast(ExecutionResult.class)
+                .map(ExecutionResult::toSpecification);
+    }
+}

--- a/graphql-java-spring-webflux/src/main/java/graphql/spring/web/reactive/subscription/GraphQLWebSocketEndpointConfiguration.java
+++ b/graphql-java-spring-webflux/src/main/java/graphql/spring/web/reactive/subscription/GraphQLWebSocketEndpointConfiguration.java
@@ -1,0 +1,44 @@
+package graphql.spring.web.reactive.subscription;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.web.reactive.HandlerMapping;
+import org.springframework.web.reactive.config.EnableWebFlux;
+import org.springframework.web.reactive.handler.SimpleUrlHandlerMapping;
+import org.springframework.web.reactive.socket.WebSocketHandler;
+import org.springframework.web.reactive.socket.server.WebSocketService;
+import org.springframework.web.reactive.socket.server.support.HandshakeWebSocketService;
+import org.springframework.web.reactive.socket.server.support.WebSocketHandlerAdapter;
+import org.springframework.web.reactive.socket.server.upgrade.ReactorNettyRequestUpgradeStrategy;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableWebFlux
+@ComponentScan
+public class GraphQLWebSocketEndpointConfiguration {
+
+    @Autowired
+    private WebSocketHandler webFluxWebSocketHandler;
+
+    @Bean
+    WebSocketHandlerAdapter webSocketHandlerAdapter(WebSocketService webSocketService) {
+        return new WebSocketHandlerAdapter(webSocketService);
+    }
+
+    @Bean
+    WebSocketService webSocketService() {
+        return new HandshakeWebSocketService(new ReactorNettyRequestUpgradeStrategy());
+    }
+
+    @Bean
+    HandlerMapping handlerMapping(@Value("${graphql.subscription.url:subscription}")String url) {
+        Map<String, WebSocketHandler> urlMap = new HashMap<>();
+        urlMap.put("/" + url, webFluxWebSocketHandler);
+        SimpleUrlHandlerMapping simpleUrlHandlerMapping = new SimpleUrlHandlerMapping();
+        simpleUrlHandlerMapping.setUrlMap(urlMap);
+        return simpleUrlHandlerMapping;
+    }
+}

--- a/graphql-java-spring-webflux/src/main/java/graphql/spring/web/reactive/subscription/WebFluxWebSocketHandler.java
+++ b/graphql-java-spring-webflux/src/main/java/graphql/spring/web/reactive/subscription/WebFluxWebSocketHandler.java
@@ -1,0 +1,41 @@
+package graphql.spring.web.reactive.subscription;
+
+import graphql.spring.web.reactive.GraphQLInvocationData;
+import graphql.spring.web.reactive.GraphQLSubscriptionInvocation;
+import graphql.spring.web.reactive.JsonSerializer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.socket.WebSocketHandler;
+import org.springframework.web.reactive.socket.WebSocketMessage;
+import org.springframework.web.reactive.socket.WebSocketSession;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+
+@Component
+public class WebFluxWebSocketHandler implements WebSocketHandler {
+
+    @Autowired
+    GraphQLSubscriptionInvocation graphQLSubscriptionInvocation;
+
+    @Autowired
+    JsonSerializer jsonSerializer;
+
+    @Override
+    public Mono<Void> handle(WebSocketSession session) {
+        Flux<WebSocketMessage> receiveMessage = session
+                .receive()
+                .map(WebSocketMessage::getPayloadAsText)
+                .flatMap(this::executeRequest)
+                .map(jsonSerializer::serialize)
+                .map(session::textMessage);
+        return session.send(receiveMessage);
+    }
+
+    private Flux<Map<String, Object>> executeRequest(String query) {
+        GraphQLInvocationData invocationData = new GraphQLInvocationData(query, null, null);
+        return graphQLSubscriptionInvocation.invoke(invocationData, null);
+    }
+
+}


### PR DESCRIPTION
- Add **EnableGraphqlSubscriptionEndpoint**  for easy setup of graphql subscription endpoint.
- The endpoint with the default `/subscription` URL is serving subscription requests. 
- To register the endpoint lazily, use a `handlerMapping` function instead of `RequestMapping` annotation 
- In the future, we would add some helper classes such as **GraphQLSusbscriptionConfigurer** and **GraphQLSusbscriptionConfigurationSupport**  to support easy customization. 