### PR TITLE
On demand data loader registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@ build
 .idea/
 out
 *.iml
+
+
+# eclipse files 
+.project
+.classpath
+.settings/
+bin/

--- a/README.md
+++ b/README.md
@@ -109,13 +109,21 @@ The following properties are currently available:
 
 ### Beans
 
-The following Beans can be overridden by providing a different implementation. 
+Several Beans can be overriden by providing a different implementation. They are in the `graphql.spring.web.reactive.components` or `graphql.spring.web.servlet.components` package, depending on whether you choose the `spring-webflux` or the `spring-webmvc` depedency.
+
+Amongs them are:
 
 | Interface | Description | 
 | --- | --- | 
 | GraphQLInvocation | Executes one request. The default impl just calls the provided `GraphQL` bean.|
 | ExecutionResultHandler | Takes a `ExecutionResult` and sends the result back to the client. The default impl returns `ExecutionResult.toSpecification()` as json. |
 
+### DataLoader
 
+The _DefaultGraphQLInvocation_ bean looks for these beans:
 
+* if an `OnDemandDataLoaderRegistry` Spring Bean is found, then its `getNewDataLoaderRegistry()` method is called for each request invocation. This allows to have one `DataLoderRegistry` per request, and so, a _per request_ cache.
 
+* else, if a `DataLoderRegistry` Spring Bean is found, then it is used for every requests. Its up to this bean to properly defined the caching strategy.
+
+* else no DataLoader is used.

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ subprojects {
         springVersion = "5.1.7.RELEASE"
         springBootVersion = "2.1.5.RELEASE"
         jacksonVersion = "2.9.8"
+        javaxAnnotation = "1.3.2"
         assertJVersion = "3.11.1"
     }
 

--- a/graphql-java-spring-webflux/build.gradle
+++ b/graphql-java-spring-webflux/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     compile "org.springframework:spring-webflux:$springVersion"
     compile "org.springframework:spring-context:$springVersion"
     compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    compile "javax.annotation:javax.annotation-api:${javaxAnnotation}"
     compile "com.graphql-java:graphql-java:$graphqlJavaVersion"
 
     testCompile("org.assertj:assertj-core:$assertJVersion")

--- a/graphql-java-spring-webflux/src/main/java/graphql/spring/web/reactive/OnDemandDataLoaderRegistry.java
+++ b/graphql-java-spring-webflux/src/main/java/graphql/spring/web/reactive/OnDemandDataLoaderRegistry.java
@@ -1,0 +1,20 @@
+package graphql.spring.web.reactive;
+
+import org.dataloader.DataLoaderRegistry;
+
+/**
+ * This interface allows to create a Spring Bean that will provide a {@link DataLoaderRegistry}, on demand. It can be
+ * used by the {@link GraphQLInvocation} bean to associate a new {@link DataLoaderRegistry} for each request.
+ * 
+ * @author etienne-sf
+ */
+public interface OnDemandDataLoaderRegistry {
+
+	/**
+	 * Retrieves a new {@link DataLoaderRegistry}, that can be associated to each request.
+	 * 
+	 * @return A new {@link DataLoaderRegistry} that is created each time this method is called.
+	 */
+	public DataLoaderRegistry getNewDataLoaderRegistry();
+
+}

--- a/graphql-java-spring-webflux/src/main/java/graphql/spring/web/reactive/components/DefaultGraphQLInvocation.java
+++ b/graphql-java-spring-webflux/src/main/java/graphql/spring/web/reactive/components/DefaultGraphQLInvocation.java
@@ -1,5 +1,10 @@
 package graphql.spring.web.reactive.components;
 
+import org.dataloader.DataLoaderRegistry;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+
 import graphql.ExecutionInput;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
@@ -7,37 +12,40 @@ import graphql.Internal;
 import graphql.spring.web.reactive.ExecutionInputCustomizer;
 import graphql.spring.web.reactive.GraphQLInvocation;
 import graphql.spring.web.reactive.GraphQLInvocationData;
-import org.dataloader.DataLoaderRegistry;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
-import org.springframework.web.server.ServerWebExchange;
+import graphql.spring.web.reactive.OnDemandDataLoaderRegistry;
 import reactor.core.publisher.Mono;
 
 @Component
 @Internal
 public class DefaultGraphQLInvocation implements GraphQLInvocation {
 
-    @Autowired
-    GraphQL graphQL;
+	@Autowired
+	GraphQL graphQL;
 
-    @Autowired(required = false)
-    DataLoaderRegistry dataLoaderRegistry;
+	@Autowired(required = false)
+	DataLoaderRegistry dataLoaderRegistry;
 
-    @Autowired
-    ExecutionInputCustomizer executionInputCustomizer;
+	@Autowired(required = false)
+	OnDemandDataLoaderRegistry onDemandDataLoaderRegistry;
 
-    @Override
-    public Mono<ExecutionResult> invoke(GraphQLInvocationData invocationData, ServerWebExchange serverWebExchange) {
-        ExecutionInput.Builder executionInputBuilder = ExecutionInput.newExecutionInput()
-                .query(invocationData.getQuery())
-                .operationName(invocationData.getOperationName())
-                .variables(invocationData.getVariables());
-        if (dataLoaderRegistry != null) {
-            executionInputBuilder.dataLoaderRegistry(dataLoaderRegistry);
-        }
-        ExecutionInput executionInput = executionInputBuilder.build();
-        Mono<ExecutionInput> customizedExecutionInputMono = executionInputCustomizer.customizeExecutionInput(executionInput, serverWebExchange);
-        return customizedExecutionInputMono.flatMap(customizedExecutionInput -> Mono.fromCompletionStage(graphQL.executeAsync(customizedExecutionInput)));
-    }
+	@Autowired
+	ExecutionInputCustomizer executionInputCustomizer;
+
+	@Override
+	public Mono<ExecutionResult> invoke(GraphQLInvocationData invocationData, ServerWebExchange serverWebExchange) {
+		ExecutionInput.Builder executionInputBuilder = ExecutionInput.newExecutionInput()
+				.query(invocationData.getQuery()).operationName(invocationData.getOperationName())
+				.variables(invocationData.getVariables());
+		if (onDemandDataLoaderRegistry != null) {
+			executionInputBuilder.dataLoaderRegistry(onDemandDataLoaderRegistry.getNewDataLoaderRegistry());
+		} else if (dataLoaderRegistry != null) {
+			executionInputBuilder.dataLoaderRegistry(dataLoaderRegistry);
+		}
+		ExecutionInput executionInput = executionInputBuilder.build();
+		Mono<ExecutionInput> customizedExecutionInputMono = executionInputCustomizer
+				.customizeExecutionInput(executionInput, serverWebExchange);
+		return customizedExecutionInputMono.flatMap(
+				customizedExecutionInput -> Mono.fromCompletionStage(graphQL.executeAsync(customizedExecutionInput)));
+	}
 
 }

--- a/graphql-java-spring-webflux/src/test/java/graphql/spring/web/reactive/components/DefaultGraphQLInvocationTest.java
+++ b/graphql-java-spring-webflux/src/test/java/graphql/spring/web/reactive/components/DefaultGraphQLInvocationTest.java
@@ -5,16 +5,29 @@ import graphql.ExecutionResult;
 import graphql.GraphQL;
 import graphql.spring.web.reactive.ExecutionInputCustomizer;
 import graphql.spring.web.reactive.GraphQLInvocationData;
+
+import org.dataloader.DataLoader;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
+import testconfig.DefaultGraphQLInvocationTest.NoDataLoaderRegistryConf;
+import testconfig.DefaultGraphQLInvocationTest.OnDemandDataLoaderRegistryConf;
+import testconfig.DefaultGraphQLInvocationTest.TestExecutionInputCustomizer;
+import testconfig.DefaultGraphQLInvocationTest.WithDataLoaderRegistryConf;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -22,41 +35,95 @@ import static org.mockito.Mockito.when;
 
 public class DefaultGraphQLInvocationTest {
 
+	public final static String DATA_LOADER_NAME = "TestDataLoader";
+	public final static String DUMMY_ERROR_MESSAGE = "This is a dummy error";
 
-    @Test
-    public void testCustomizerIsCalled() {
+	@Test
+	public void testCustomizerIsCalled() {
 
-        String query = "query myQuery {foo}";
-        String operationName = "myQuery";
-        Map<String, Object> variables = new LinkedHashMap<>();
+		String query = "query myQuery {foo}";
+		String operationName = "myQuery";
+		Map<String, Object> variables = new LinkedHashMap<>();
 
-        DefaultGraphQLInvocation defaultGraphQLInvocation = new DefaultGraphQLInvocation();
-        ExecutionInputCustomizer executionInputCustomizer = mock(ExecutionInputCustomizer.class);
-        defaultGraphQLInvocation.executionInputCustomizer = executionInputCustomizer;
-        GraphQL graphQL = mock(GraphQL.class);
-        defaultGraphQLInvocation.graphQL = graphQL;
-        ExecutionResult executionResult = mock(ExecutionResult.class);
-        when(graphQL.executeAsync(any(ExecutionInput.class))).thenReturn(completedFuture(executionResult));
+		DefaultGraphQLInvocation defaultGraphQLInvocation = new DefaultGraphQLInvocation();
+		ExecutionInputCustomizer executionInputCustomizer = mock(ExecutionInputCustomizer.class);
+		defaultGraphQLInvocation.executionInputCustomizer = executionInputCustomizer;
+		GraphQL graphQL = mock(GraphQL.class);
+		defaultGraphQLInvocation.graphQL = graphQL;
+		ExecutionResult executionResult = mock(ExecutionResult.class);
+		when(graphQL.executeAsync(any(ExecutionInput.class))).thenReturn(completedFuture(executionResult));
 
-        GraphQLInvocationData graphQLInvocationData = new GraphQLInvocationData(query, operationName, variables);
-        ServerWebExchange serverWebExchange = mock(ServerWebExchange.class);
+		GraphQLInvocationData graphQLInvocationData = new GraphQLInvocationData(query, operationName, variables);
+		ServerWebExchange serverWebExchange = mock(ServerWebExchange.class);
 
-        ArgumentCaptor<ExecutionInput> captor1 = ArgumentCaptor.forClass(ExecutionInput.class);
-        ArgumentCaptor<ServerWebExchange> captor2 = ArgumentCaptor.forClass(ServerWebExchange.class);
-        ExecutionInput executionInputResult = mock(ExecutionInput.class);
-        when(executionInputCustomizer.customizeExecutionInput(captor1.capture(), captor2.capture())).thenReturn(Mono.just(executionInputResult));
+		ArgumentCaptor<ExecutionInput> captor1 = ArgumentCaptor.forClass(ExecutionInput.class);
+		ArgumentCaptor<ServerWebExchange> captor2 = ArgumentCaptor.forClass(ServerWebExchange.class);
+		ExecutionInput executionInputResult = mock(ExecutionInput.class);
+		when(executionInputCustomizer.customizeExecutionInput(captor1.capture(), captor2.capture()))
+				.thenReturn(Mono.just(executionInputResult));
 
-        Mono<ExecutionResult> invoke = defaultGraphQLInvocation.invoke(graphQLInvocationData, serverWebExchange);
+		Mono<ExecutionResult> invoke = defaultGraphQLInvocation.invoke(graphQLInvocationData, serverWebExchange);
 
-        assertThat(captor1.getValue().getQuery()).isEqualTo(query);
-        assertThat(captor1.getValue().getOperationName()).isEqualTo(operationName);
-        assertThat(captor1.getValue().getVariables()).isSameAs(variables);
+		assertThat(captor1.getValue().getQuery()).isEqualTo(query);
+		assertThat(captor1.getValue().getOperationName()).isEqualTo(operationName);
+		assertThat(captor1.getValue().getVariables()).isSameAs(variables);
 
-        invoke.block();
+		invoke.block();
 
-        verify(graphQL).executeAsync(executionInputResult);
+		verify(graphQL).executeAsync(executionInputResult);
 
-    }
+	}
 
+	@Test
+	public void testNoDataLoader() {
+		ApplicationContext ctx = new AnnotationConfigApplicationContext(NoDataLoaderRegistryConf.class);
+
+		DataLoader<?, ?> dl = invokeRequestAndGetDataLoader(ctx);
+		assertNull("no data loader should exist in the request context", dl);
+	}
+
+	@Test
+	public void testWithDataLoader() {
+		ApplicationContext ctx = new AnnotationConfigApplicationContext(WithDataLoaderRegistryConf.class);
+
+		DataLoader<?, ?> dl1 = invokeRequestAndGetDataLoader(ctx);
+		DataLoader<?, ?> dl2 = invokeRequestAndGetDataLoader(ctx);
+
+		assertNotNull("A data loader should exist in the request context (1)", dl1);
+		assertNotNull("A data loader should exist in the request context (2)", dl2);
+		assertEquals("The DataLoader should be the same one accross two request invocations", dl1, dl2);
+	}
+
+	@Test
+	public void testOnDemandeDataLoader() {
+		ApplicationContext ctx = new AnnotationConfigApplicationContext(OnDemandDataLoaderRegistryConf.class);
+
+		DataLoader<?, ?> dl1 = invokeRequestAndGetDataLoader(ctx);
+		DataLoader<?, ?> dl2 = invokeRequestAndGetDataLoader(ctx);
+
+		assertNotNull("A data loader should exist in the request context (1)", dl1);
+		assertNotNull("A data loader should exist in the request context (2)", dl2);
+		assertNotEquals("The DataLoader should NOT be the same one accross two request invocations", dl1, dl2);
+	}
+
+	private DataLoader<?, ?> invokeRequestAndGetDataLoader(ApplicationContext ctx) {
+		DefaultGraphQLInvocation defaultGraphQLInvocation = ctx.getBean(DefaultGraphQLInvocation.class);
+		assertNotNull(defaultGraphQLInvocation);
+
+		TestExecutionInputCustomizer executionInputCustomizer = ctx.getBean(TestExecutionInputCustomizer.class);
+
+		try {
+			String query = "query{helloWorld}";
+			String operationName = "query";
+			defaultGraphQLInvocation.invoke(new GraphQLInvocationData(query, operationName, null), null);
+			fail("This text expects an exception");
+			// The next line will never be executed. But it is needed, as it is needed to avoid compilation error.
+			return null;
+		} catch (RuntimeException e) {
+			assertEquals(DUMMY_ERROR_MESSAGE, e.getMessage());
+			return (executionInputCustomizer.lastReadDataLoaderRegistry == null) ? null
+					: executionInputCustomizer.lastReadDataLoaderRegistry.getDataLoader(DATA_LOADER_NAME);
+		}
+	}
 
 }

--- a/graphql-java-spring-webflux/src/test/java/testconfig/DefaultGraphQLInvocationTest/BatchLoaderImpl.java
+++ b/graphql-java-spring-webflux/src/test/java/testconfig/DefaultGraphQLInvocationTest/BatchLoaderImpl.java
@@ -1,0 +1,24 @@
+package testconfig.DefaultGraphQLInvocationTest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import org.dataloader.BatchLoaderEnvironment;
+import org.dataloader.BatchLoaderWithContext;
+
+/** A batch loader that can be declared into the DataLoader */
+public class BatchLoaderImpl implements BatchLoaderWithContext<Long, String> {
+	@Override
+	public CompletionStage<List<String>> load(List<Long> keys, BatchLoaderEnvironment environment) {
+		return CompletableFuture.supplyAsync(() -> {
+			List<String> ret = new ArrayList<>(keys.size());
+			for (Long key : keys) {
+				ret.add(key.toString());
+			}
+			return ret;
+		});
+	}
+}
+

--- a/graphql-java-spring-webflux/src/test/java/testconfig/DefaultGraphQLInvocationTest/NoDataLoaderRegistryConf.java
+++ b/graphql-java-spring-webflux/src/test/java/testconfig/DefaultGraphQLInvocationTest/NoDataLoaderRegistryConf.java
@@ -1,0 +1,51 @@
+package testconfig.DefaultGraphQLInvocationTest;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import graphql.GraphQL;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaGenerator;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import graphql.spring.web.reactive.components.GraphQLController;
+
+/**
+ * Spring {@link Configuration} file for the {@link DefaultGraphQLInvocationTest#testNoDataLoader()} test.
+ * 
+ * @author etienne-sf
+ */
+@Configuration
+@ComponentScan(basePackageClasses = GraphQLController.class)
+public class NoDataLoaderRegistryConf {
+
+	// This beans traps the {@link DataLoaderRegistry} at each request invocation
+	@Bean
+	@Primary
+	TestExecutionInputCustomizer testExecutionInputCustomizer() {
+		return new TestExecutionInputCustomizer();
+	}
+
+	@Bean
+	ObjectMapper objectMapper() {
+		// It won't be used
+		return new ObjectMapper();
+	}
+
+	@Bean
+	public GraphQL graphQL() {
+		String schema = "type Query{helloWorld: String}";
+		TypeDefinitionRegistry typeRegistry = new SchemaParser().parse(schema);
+		RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring().build();
+		SchemaGenerator schemaGenerator = new SchemaGenerator();
+		GraphQLSchema graphQLSchema = schemaGenerator.makeExecutableSchema(typeRegistry, runtimeWiring);
+
+		return GraphQL.newGraphQL(graphQLSchema).build();
+	}
+
+}

--- a/graphql-java-spring-webflux/src/test/java/testconfig/DefaultGraphQLInvocationTest/OnDemandDataLoaderRegistryConf.java
+++ b/graphql-java-spring-webflux/src/test/java/testconfig/DefaultGraphQLInvocationTest/OnDemandDataLoaderRegistryConf.java
@@ -1,0 +1,67 @@
+package testconfig.DefaultGraphQLInvocationTest;
+
+import org.dataloader.DataLoader;
+import org.dataloader.DataLoaderRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import graphql.GraphQL;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaGenerator;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import graphql.spring.web.reactive.OnDemandDataLoaderRegistry;
+import graphql.spring.web.reactive.components.DefaultGraphQLInvocationTest;
+import graphql.spring.web.reactive.components.GraphQLController;
+
+/**
+ * Spring {@link Configuration} file for the {@link DefaultGraphQLInvocationTest#testOnDemandeDataLoader()} test.
+ * 
+ * @author etienne-sf
+ */
+@Configuration
+@ComponentScan(basePackageClasses = GraphQLController.class)
+public class OnDemandDataLoaderRegistryConf {
+
+	@Bean
+	public OnDemandDataLoaderRegistry onDemandDataLoaderRegistry() {
+		return new OnDemandDataLoaderRegistry() {
+			@Override
+			public DataLoaderRegistry getNewDataLoaderRegistry() {
+				DataLoaderRegistry registry = new DataLoaderRegistry();
+				registry.register(DefaultGraphQLInvocationTest.DATA_LOADER_NAME,
+						DataLoader.newDataLoader(new BatchLoaderImpl()));
+				return registry;
+			}
+		};
+	}
+
+	// This beans traps the {@link DataLoaderRegistry} at each request invocation
+	@Bean
+	@Primary
+	TestExecutionInputCustomizer testExecutionInputCustomizer() {
+		return new TestExecutionInputCustomizer();
+	}
+
+	@Bean
+	ObjectMapper objectMapper() {
+		// It won't be used
+		return new ObjectMapper();
+	}
+
+	@Bean
+	public GraphQL graphQL() {
+		String schema = "type Query{helloWorld: String}";
+		TypeDefinitionRegistry typeRegistry = new SchemaParser().parse(schema);
+		RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring().build();
+		SchemaGenerator schemaGenerator = new SchemaGenerator();
+		GraphQLSchema graphQLSchema = schemaGenerator.makeExecutableSchema(typeRegistry, runtimeWiring);
+
+		return GraphQL.newGraphQL(graphQLSchema).build();
+	}
+}

--- a/graphql-java-spring-webflux/src/test/java/testconfig/DefaultGraphQLInvocationTest/TestExecutionInputCustomizer.java
+++ b/graphql-java-spring-webflux/src/test/java/testconfig/DefaultGraphQLInvocationTest/TestExecutionInputCustomizer.java
@@ -1,0 +1,34 @@
+package testconfig.DefaultGraphQLInvocationTest;
+
+import org.dataloader.DataLoaderRegistry;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+
+import graphql.ExecutionInput;
+import graphql.spring.web.reactive.ExecutionInputCustomizer;
+import graphql.spring.web.reactive.components.DefaultGraphQLInvocationTest;
+import reactor.core.publisher.Mono;
+
+/**
+ * This Test class allows to catch the DataLoaderRegistry that is defined in the request context (if any) at each
+ * request invocation.<BR/>
+ * It must be loaded as a Spring Bean, in the Spring context. But <U>only for the {@link DefaultGraphQLInvocationTest}
+ * test class</U>. So it's NOT marked by the @{@link Component} annotation. It's loaded as a bean in the
+ * {@link Configuration} classes of this package, to be reused by the various Spring {@link Configuration}s that is
+ * contains.
+ */
+public class TestExecutionInputCustomizer implements ExecutionInputCustomizer {
+	public DataLoaderRegistry lastReadDataLoaderRegistry;
+
+	@Override
+	public Mono<ExecutionInput> customizeExecutionInput(ExecutionInput executionInput, ServerWebExchange webRequest) {
+		lastReadDataLoaderRegistry = executionInput.getDataLoaderRegistry();
+
+		// The test context doesn't allow to execute a real request. And the job is done: we've caught tyhe
+		// DataLoaderRegistry.
+		// So let's manage our specific exception, to stop here.
+		throw new RuntimeException(DefaultGraphQLInvocationTest.DUMMY_ERROR_MESSAGE);
+	}
+
+}

--- a/graphql-java-spring-webflux/src/test/java/testconfig/DefaultGraphQLInvocationTest/WithDataLoaderRegistryConf.java
+++ b/graphql-java-spring-webflux/src/test/java/testconfig/DefaultGraphQLInvocationTest/WithDataLoaderRegistryConf.java
@@ -1,0 +1,62 @@
+package testconfig.DefaultGraphQLInvocationTest;
+
+import org.dataloader.DataLoader;
+import org.dataloader.DataLoaderRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import graphql.GraphQL;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaGenerator;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import graphql.spring.web.reactive.components.DefaultGraphQLInvocationTest;
+import graphql.spring.web.reactive.components.GraphQLController;
+
+/**
+ * Spring {@link Configuration} file for the {@link DefaultGraphQLInvocationTest#testWithDataLoader()} test.
+ * 
+ * @author etienne-sf
+ */
+@Configuration
+@ComponentScan(basePackageClasses = GraphQLController.class)
+public class WithDataLoaderRegistryConf {
+
+	@Bean
+	public DataLoaderRegistry dataLoaderRegistry() {
+		DataLoaderRegistry registry = new DataLoaderRegistry();
+		registry.register(DefaultGraphQLInvocationTest.DATA_LOADER_NAME,
+				DataLoader.newDataLoader(new BatchLoaderImpl()));
+		return registry;
+	}
+
+	// This beans traps the {@link DataLoaderRegistry} at each request invocation
+	@Bean
+	@Primary
+	TestExecutionInputCustomizer testExecutionInputCustomizer() {
+		return new TestExecutionInputCustomizer();
+	}
+
+	@Bean
+	ObjectMapper objectMapper() {
+		// It won't be used
+		return new ObjectMapper();
+	}
+
+	@Bean
+	public GraphQL graphQL() {
+		String schema = "type Query{helloWorld: String}";
+		TypeDefinitionRegistry typeRegistry = new SchemaParser().parse(schema);
+		RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring().build();
+		SchemaGenerator schemaGenerator = new SchemaGenerator();
+		GraphQLSchema graphQLSchema = schemaGenerator.makeExecutableSchema(typeRegistry, runtimeWiring);
+
+		return GraphQL.newGraphQL(graphQLSchema).build();
+	}
+
+}

--- a/graphql-java-spring-webmvc/build.gradle
+++ b/graphql-java-spring-webmvc/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     compile "org.springframework:spring-webmvc:$springVersion"
     compile "org.springframework:spring-context:$springVersion"
     compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    compile "javax.annotation:javax.annotation-api:${javaxAnnotation}"
     compile "com.graphql-java:graphql-java:$graphqlJavaVersion"
 
     testCompile("org.assertj:assertj-core:$assertJVersion")

--- a/graphql-java-spring-webmvc/src/main/java/graphql/spring/web/servlet/OnDemandDataLoaderRegistry.java
+++ b/graphql-java-spring-webmvc/src/main/java/graphql/spring/web/servlet/OnDemandDataLoaderRegistry.java
@@ -1,0 +1,20 @@
+package graphql.spring.web.servlet;
+
+import org.dataloader.DataLoaderRegistry;
+
+/**
+ * This interface allows to create a Spring Bean that will provide a {@link DataLoaderRegistry}, on demand. It can be
+ * used by the {@link GraphQLInvocation} bean to associate a new {@link DataLoaderRegistry} for each request.
+ * 
+ * @author etienne-sf
+ */
+public interface OnDemandDataLoaderRegistry {
+
+	/**
+	 * Retrieves a new {@link DataLoaderRegistry}, that can be associated to each request.
+	 * 
+	 * @return A new {@link DataLoaderRegistry} that is created each time this method is called.
+	 */
+	public DataLoaderRegistry getNewDataLoaderRegistry();
+
+}

--- a/graphql-java-spring-webmvc/src/main/java/graphql/spring/web/servlet/components/DefaultGraphQLInvocation.java
+++ b/graphql-java-spring-webmvc/src/main/java/graphql/spring/web/servlet/components/DefaultGraphQLInvocation.java
@@ -1,5 +1,12 @@
 package graphql.spring.web.servlet.components;
 
+import java.util.concurrent.CompletableFuture;
+
+import org.dataloader.DataLoaderRegistry;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.WebRequest;
+
 import graphql.ExecutionInput;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
@@ -7,38 +14,38 @@ import graphql.Internal;
 import graphql.spring.web.servlet.ExecutionInputCustomizer;
 import graphql.spring.web.servlet.GraphQLInvocation;
 import graphql.spring.web.servlet.GraphQLInvocationData;
-import org.dataloader.DataLoaderRegistry;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
-import org.springframework.web.context.request.WebRequest;
-
-import java.util.concurrent.CompletableFuture;
+import graphql.spring.web.servlet.OnDemandDataLoaderRegistry;
 
 @Component
 @Internal
 public class DefaultGraphQLInvocation implements GraphQLInvocation {
 
-    @Autowired
-    GraphQL graphQL;
+	@Autowired
+	GraphQL graphQL;
 
-    @Autowired(required = false)
-    DataLoaderRegistry dataLoaderRegistry;
+	@Autowired(required = false)
+	DataLoaderRegistry dataLoaderRegistry;
 
-    @Autowired
-    ExecutionInputCustomizer executionInputCustomizer;
+	@Autowired(required = false)
+	OnDemandDataLoaderRegistry onDemandDataLoaderRegistry;
 
-    @Override
-    public CompletableFuture<ExecutionResult> invoke(GraphQLInvocationData invocationData, WebRequest webRequest) {
-        ExecutionInput.Builder executionInputBuilder = ExecutionInput.newExecutionInput()
-                .query(invocationData.getQuery())
-                .operationName(invocationData.getOperationName())
-                .variables(invocationData.getVariables());
-        if (dataLoaderRegistry != null) {
-            executionInputBuilder.dataLoaderRegistry(dataLoaderRegistry);
-        }
-        ExecutionInput executionInput = executionInputBuilder.build();
-        CompletableFuture<ExecutionInput> customizedExecutionInput = executionInputCustomizer.customizeExecutionInput(executionInput, webRequest);
-        return customizedExecutionInput.thenCompose(graphQL::executeAsync);
-    }
+	@Autowired
+	ExecutionInputCustomizer executionInputCustomizer;
+
+	@Override
+	public CompletableFuture<ExecutionResult> invoke(GraphQLInvocationData invocationData, WebRequest webRequest) {
+		ExecutionInput.Builder executionInputBuilder = ExecutionInput.newExecutionInput()
+				.query(invocationData.getQuery()).operationName(invocationData.getOperationName())
+				.variables(invocationData.getVariables());
+		if (onDemandDataLoaderRegistry != null) {
+			executionInputBuilder.dataLoaderRegistry(onDemandDataLoaderRegistry.getNewDataLoaderRegistry());
+		} else if (dataLoaderRegistry != null) {
+			executionInputBuilder.dataLoaderRegistry(dataLoaderRegistry);
+		}
+		ExecutionInput executionInput = executionInputBuilder.build();
+		CompletableFuture<ExecutionInput> customizedExecutionInput = executionInputCustomizer
+				.customizeExecutionInput(executionInput, webRequest);
+		return customizedExecutionInput.thenCompose(graphQL::executeAsync);
+	}
 
 }

--- a/graphql-java-spring-webmvc/src/test/java/graphql/spring/web/servlet/components/DefaultGraphQLInvocationTest.java
+++ b/graphql-java-spring-webmvc/src/test/java/graphql/spring/web/servlet/components/DefaultGraphQLInvocationTest.java
@@ -1,59 +1,124 @@
 package graphql.spring.web.servlet.components;
 
-import graphql.ExecutionInput;
-import graphql.ExecutionResult;
-import graphql.GraphQL;
-import graphql.spring.web.servlet.ExecutionInputCustomizer;
-import graphql.spring.web.servlet.GraphQLInvocationData;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.springframework.web.context.request.WebRequest;
-
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.dataloader.DataLoader;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.web.context.request.WebRequest;
+
+import graphql.ExecutionInput;
+import graphql.ExecutionResult;
+import graphql.GraphQL;
+import graphql.spring.web.servlet.ExecutionInputCustomizer;
+import graphql.spring.web.servlet.GraphQLInvocationData;
+import testconfig.DefaultGraphQLInvocationTest.NoDataLoaderRegistryConf;
+import testconfig.DefaultGraphQLInvocationTest.OnDemandDataLoaderRegistryConf;
+import testconfig.DefaultGraphQLInvocationTest.TestExecutionInputCustomizer;
+import testconfig.DefaultGraphQLInvocationTest.WithDataLoaderRegistryConf;
+
 public class DefaultGraphQLInvocationTest {
 
+	public final static String DATA_LOADER_NAME = "TestDataLoader";
+	public final static String DUMMY_ERROR_MESSAGE = "This is a dummy error";
 
-    @Test
-    public void testCustomizerIsCalled() {
+	@Test
+	public void testCustomizerIsCalled() {
 
-        String query = "query myQuery {foo}";
-        String operationName = "myQuery";
-        Map<String, Object> variables = new LinkedHashMap<>();
+		String query = "query myQuery {foo}";
+		String operationName = "myQuery";
+		Map<String, Object> variables = new LinkedHashMap<>();
 
-        DefaultGraphQLInvocation defaultGraphQLInvocation = new DefaultGraphQLInvocation();
-        ExecutionInputCustomizer executionInputCustomizer = mock(ExecutionInputCustomizer.class);
-        defaultGraphQLInvocation.executionInputCustomizer = executionInputCustomizer;
-        GraphQL graphQL = mock(GraphQL.class);
-        defaultGraphQLInvocation.graphQL = graphQL;
-        ExecutionResult executionResult = mock(ExecutionResult.class);
-        when(graphQL.executeAsync(any(ExecutionInput.class))).thenReturn(completedFuture(executionResult));
+		DefaultGraphQLInvocation defaultGraphQLInvocation = new DefaultGraphQLInvocation();
+		ExecutionInputCustomizer executionInputCustomizer = mock(ExecutionInputCustomizer.class);
+		defaultGraphQLInvocation.executionInputCustomizer = executionInputCustomizer;
+		GraphQL graphQL = mock(GraphQL.class);
+		defaultGraphQLInvocation.graphQL = graphQL;
+		ExecutionResult executionResult = mock(ExecutionResult.class);
+		when(graphQL.executeAsync(any(ExecutionInput.class))).thenReturn(completedFuture(executionResult));
 
-        GraphQLInvocationData graphQLInvocationData = new GraphQLInvocationData(query, operationName, variables);
-        WebRequest webRequest = mock(WebRequest.class);
+		GraphQLInvocationData graphQLInvocationData = new GraphQLInvocationData(query, operationName, variables);
+		WebRequest webRequest = mock(WebRequest.class);
 
-        ArgumentCaptor<ExecutionInput> captor1 = ArgumentCaptor.forClass(ExecutionInput.class);
-        ArgumentCaptor<WebRequest> captor2 = ArgumentCaptor.forClass(WebRequest.class);
-        ExecutionInput executionInputResult = mock(ExecutionInput.class);
-        when(executionInputCustomizer.customizeExecutionInput(captor1.capture(), captor2.capture())).thenReturn(completedFuture(executionInputResult));
+		ArgumentCaptor<ExecutionInput> captor1 = ArgumentCaptor.forClass(ExecutionInput.class);
+		ArgumentCaptor<WebRequest> captor2 = ArgumentCaptor.forClass(WebRequest.class);
+		ExecutionInput executionInputResult = mock(ExecutionInput.class);
+		when(executionInputCustomizer.customizeExecutionInput(captor1.capture(), captor2.capture()))
+				.thenReturn(completedFuture(executionInputResult));
 
-        CompletableFuture<ExecutionResult> invoke = defaultGraphQLInvocation.invoke(graphQLInvocationData, webRequest);
+		defaultGraphQLInvocation.invoke(graphQLInvocationData, webRequest);
 
-        assertThat(captor1.getValue().getQuery()).isEqualTo(query);
-        assertThat(captor1.getValue().getOperationName()).isEqualTo(operationName);
-        assertThat(captor1.getValue().getVariables()).isSameAs(variables);
+		assertThat(captor1.getValue().getQuery()).isEqualTo(query);
+		assertThat(captor1.getValue().getOperationName()).isEqualTo(operationName);
+		assertThat(captor1.getValue().getVariables()).isSameAs(variables);
 
-        verify(graphQL).executeAsync(executionInputResult);
+		verify(graphQL).executeAsync(executionInputResult);
+	}
 
-    }
+	@Test
+	public void testNoDataLoader() {
+		ApplicationContext ctx = new AnnotationConfigApplicationContext(NoDataLoaderRegistryConf.class);
 
+		DataLoader<?, ?> dl = invokeRequestAndGetDataLoader(ctx);
+		assertNull("no data loader should exist in the request context", dl);
+	}
+
+	@Test
+	public void testWithDataLoader() {
+		ApplicationContext ctx = new AnnotationConfigApplicationContext(WithDataLoaderRegistryConf.class);
+
+		DataLoader<?, ?> dl1 = invokeRequestAndGetDataLoader(ctx);
+		DataLoader<?, ?> dl2 = invokeRequestAndGetDataLoader(ctx);
+
+		assertNotNull("A data loader should exist in the request context (1)", dl1);
+		assertNotNull("A data loader should exist in the request context (2)", dl2);
+		assertEquals("The DataLoader should be the same one accross two request invocations", dl1, dl2);
+	}
+
+	@Test
+	public void testOnDemandeDataLoader() {
+		ApplicationContext ctx = new AnnotationConfigApplicationContext(OnDemandDataLoaderRegistryConf.class);
+
+		DataLoader<?, ?> dl1 = invokeRequestAndGetDataLoader(ctx);
+		DataLoader<?, ?> dl2 = invokeRequestAndGetDataLoader(ctx);
+
+		assertNotNull("A data loader should exist in the request context (1)", dl1);
+		assertNotNull("A data loader should exist in the request context (2)", dl2);
+		assertNotEquals("The DataLoader should NOT be the same one accross two request invocations", dl1, dl2);
+	}
+
+	private DataLoader<?, ?> invokeRequestAndGetDataLoader(ApplicationContext ctx) {
+		DefaultGraphQLInvocation defaultGraphQLInvocation = ctx.getBean(DefaultGraphQLInvocation.class);
+		assertNotNull(defaultGraphQLInvocation);
+
+		TestExecutionInputCustomizer executionInputCustomizer = ctx.getBean(TestExecutionInputCustomizer.class);
+
+		try {
+			String query = "query{helloWorld}";
+			String operationName = "query";
+			defaultGraphQLInvocation.invoke(new GraphQLInvocationData(query, operationName, null), null);
+			fail("This text expects an exception");
+			// The next line will never be executed. But it is needed, as it is needed to avoid compilation error.
+			return null;
+		} catch (RuntimeException e) {
+			assertEquals(DUMMY_ERROR_MESSAGE, e.getMessage());
+			return (executionInputCustomizer.lastReadDataLoaderRegistry == null) ? null
+					: executionInputCustomizer.lastReadDataLoaderRegistry.getDataLoader(DATA_LOADER_NAME);
+		}
+	}
 }

--- a/graphql-java-spring-webmvc/src/test/java/testconfig/DefaultGraphQLInvocationTest/BatchLoaderImpl.java
+++ b/graphql-java-spring-webmvc/src/test/java/testconfig/DefaultGraphQLInvocationTest/BatchLoaderImpl.java
@@ -1,0 +1,24 @@
+package testconfig.DefaultGraphQLInvocationTest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import org.dataloader.BatchLoaderEnvironment;
+import org.dataloader.BatchLoaderWithContext;
+
+/** A batch loader that can be declared into the DataLoader */
+public class BatchLoaderImpl implements BatchLoaderWithContext<Long, String> {
+	@Override
+	public CompletionStage<List<String>> load(List<Long> keys, BatchLoaderEnvironment environment) {
+		return CompletableFuture.supplyAsync(() -> {
+			List<String> ret = new ArrayList<>(keys.size());
+			for (Long key : keys) {
+				ret.add(key.toString());
+			}
+			return ret;
+		});
+	}
+}
+

--- a/graphql-java-spring-webmvc/src/test/java/testconfig/DefaultGraphQLInvocationTest/NoDataLoaderRegistryConf.java
+++ b/graphql-java-spring-webmvc/src/test/java/testconfig/DefaultGraphQLInvocationTest/NoDataLoaderRegistryConf.java
@@ -1,0 +1,52 @@
+package testconfig.DefaultGraphQLInvocationTest;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import graphql.GraphQL;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaGenerator;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import graphql.spring.web.servlet.components.DefaultGraphQLInvocationTest;
+import graphql.spring.web.servlet.components.GraphQLController;
+
+/**
+ * Spring {@link Configuration} file for the {@link DefaultGraphQLInvocationTest#testNoDataLoader()} test.
+ * 
+ * @author etienne-sf
+ */
+@Configuration
+@ComponentScan(basePackageClasses = GraphQLController.class)
+public class NoDataLoaderRegistryConf {
+
+	// This beans traps the {@link DataLoaderRegistry} at each request invocation
+	@Bean
+	@Primary
+	TestExecutionInputCustomizer testExecutionInputCustomizer() {
+		return new TestExecutionInputCustomizer();
+	}
+
+	@Bean
+	ObjectMapper objectMapper() {
+		// It won't be used
+		return new ObjectMapper();
+	}
+
+	@Bean
+	public GraphQL graphQL() {
+		String schema = "type Query{helloWorld: String}";
+		TypeDefinitionRegistry typeRegistry = new SchemaParser().parse(schema);
+		RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring().build();
+		SchemaGenerator schemaGenerator = new SchemaGenerator();
+		GraphQLSchema graphQLSchema = schemaGenerator.makeExecutableSchema(typeRegistry, runtimeWiring);
+
+		return GraphQL.newGraphQL(graphQLSchema).build();
+	}
+
+}

--- a/graphql-java-spring-webmvc/src/test/java/testconfig/DefaultGraphQLInvocationTest/OnDemandDataLoaderRegistryConf.java
+++ b/graphql-java-spring-webmvc/src/test/java/testconfig/DefaultGraphQLInvocationTest/OnDemandDataLoaderRegistryConf.java
@@ -1,0 +1,67 @@
+package testconfig.DefaultGraphQLInvocationTest;
+
+import org.dataloader.DataLoader;
+import org.dataloader.DataLoaderRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import graphql.GraphQL;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaGenerator;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import graphql.spring.web.servlet.OnDemandDataLoaderRegistry;
+import graphql.spring.web.servlet.components.DefaultGraphQLInvocationTest;
+import graphql.spring.web.servlet.components.GraphQLController;
+
+/**
+ * Spring {@link Configuration} file for the {@link DefaultGraphQLInvocationTest#testOnDemandeDataLoader()} test.
+ * 
+ * @author etienne-sf
+ */
+@Configuration
+@ComponentScan(basePackageClasses = GraphQLController.class)
+public class OnDemandDataLoaderRegistryConf {
+
+	@Bean
+	public OnDemandDataLoaderRegistry onDemandDataLoaderRegistry() {
+		return new OnDemandDataLoaderRegistry() {
+			@Override
+			public DataLoaderRegistry getNewDataLoaderRegistry() {
+				DataLoaderRegistry registry = new DataLoaderRegistry();
+				registry.register(DefaultGraphQLInvocationTest.DATA_LOADER_NAME,
+						DataLoader.newDataLoader(new BatchLoaderImpl()));
+				return registry;
+			}
+		};
+	}
+
+	// This beans traps the {@link DataLoaderRegistry} at each request invocation
+	@Bean
+	@Primary
+	TestExecutionInputCustomizer testExecutionInputCustomizer() {
+		return new TestExecutionInputCustomizer();
+	}
+
+	@Bean
+	ObjectMapper objectMapper() {
+		// It won't be used
+		return new ObjectMapper();
+	}
+
+	@Bean
+	public GraphQL graphQL() {
+		String schema = "type Query{helloWorld: String}";
+		TypeDefinitionRegistry typeRegistry = new SchemaParser().parse(schema);
+		RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring().build();
+		SchemaGenerator schemaGenerator = new SchemaGenerator();
+		GraphQLSchema graphQLSchema = schemaGenerator.makeExecutableSchema(typeRegistry, runtimeWiring);
+
+		return GraphQL.newGraphQL(graphQLSchema).build();
+	}
+}

--- a/graphql-java-spring-webmvc/src/test/java/testconfig/DefaultGraphQLInvocationTest/TestExecutionInputCustomizer.java
+++ b/graphql-java-spring-webmvc/src/test/java/testconfig/DefaultGraphQLInvocationTest/TestExecutionInputCustomizer.java
@@ -1,0 +1,36 @@
+package testconfig.DefaultGraphQLInvocationTest;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.dataloader.DataLoaderRegistry;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.WebRequest;
+
+import graphql.ExecutionInput;
+import graphql.spring.web.servlet.ExecutionInputCustomizer;
+import graphql.spring.web.servlet.components.DefaultGraphQLInvocationTest;
+
+/**
+ * This Test class allows to catch the DataLoaderRegistry that is defined in the request context (if any) at each
+ * request invocation.<BR/>
+ * It must be loaded as a Spring Bean, in the Spring context. But <U>only for the {@link DefaultGraphQLInvocationTest}
+ * test class</U>. So it's NOT marked by the @{@link Component} annotation. It's loaded as a bean in the
+ * {@link Configuration} classes of this package, to be reused by the various Spring {@link Configuration}s that is
+ * contains.
+ */
+public class TestExecutionInputCustomizer implements ExecutionInputCustomizer {
+	public DataLoaderRegistry lastReadDataLoaderRegistry;
+
+	@Override
+	public CompletableFuture<ExecutionInput> customizeExecutionInput(ExecutionInput executionInput,
+			WebRequest webRequest) {
+		lastReadDataLoaderRegistry = executionInput.getDataLoaderRegistry();
+
+		// The test context doesn't allow to execute a real request. And the job is done: we've caught tyhe
+		// DataLoaderRegistry.
+		// So let's manage our specific exception, to stop here.
+		throw new RuntimeException(DefaultGraphQLInvocationTest.DUMMY_ERROR_MESSAGE);
+	}
+
+}

--- a/graphql-java-spring-webmvc/src/test/java/testconfig/DefaultGraphQLInvocationTest/WithDataLoaderRegistryConf.java
+++ b/graphql-java-spring-webmvc/src/test/java/testconfig/DefaultGraphQLInvocationTest/WithDataLoaderRegistryConf.java
@@ -1,0 +1,62 @@
+package testconfig.DefaultGraphQLInvocationTest;
+
+import org.dataloader.DataLoader;
+import org.dataloader.DataLoaderRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import graphql.GraphQL;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaGenerator;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import graphql.spring.web.servlet.components.DefaultGraphQLInvocationTest;
+import graphql.spring.web.servlet.components.GraphQLController;
+
+/**
+ * Spring {@link Configuration} file for the {@link DefaultGraphQLInvocationTest#testWithDataLoader()} test.
+ * 
+ * @author etienne-sf
+ */
+@Configuration
+@ComponentScan(basePackageClasses = GraphQLController.class)
+public class WithDataLoaderRegistryConf {
+
+	@Bean
+	public DataLoaderRegistry dataLoaderRegistry() {
+		DataLoaderRegistry registry = new DataLoaderRegistry();
+		registry.register(DefaultGraphQLInvocationTest.DATA_LOADER_NAME,
+				DataLoader.newDataLoader(new BatchLoaderImpl()));
+		return registry;
+	}
+
+	// This beans traps the {@link DataLoaderRegistry} at each request invocation
+	@Bean
+	@Primary
+	TestExecutionInputCustomizer testExecutionInputCustomizer() {
+		return new TestExecutionInputCustomizer();
+	}
+
+	@Bean
+	ObjectMapper objectMapper() {
+		// It won't be used
+		return new ObjectMapper();
+	}
+
+	@Bean
+	public GraphQL graphQL() {
+		String schema = "type Query{helloWorld: String}";
+		TypeDefinitionRegistry typeRegistry = new SchemaParser().parse(schema);
+		RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring().build();
+		SchemaGenerator schemaGenerator = new SchemaGenerator();
+		GraphQLSchema graphQLSchema = schemaGenerator.makeExecutableSchema(typeRegistry, runtimeWiring);
+
+		return GraphQL.newGraphQL(graphQLSchema).build();
+	}
+
+}


### PR DESCRIPTION
Hello,

I'm building on the [graphql-maven-plugin-project](https://github.com/graphql-java-generator/graphql-maven-plugin-project) that is both a Maven and a Gradle plugin. It generates the code that allows to easily develop a java GraphQL client, or a GraphQL server (it just generated the code that allows to directly use graphql-java).

On server side, this plugin faces the issue that the DataLoader is loaded once. And so, the cache is global, and not _per request_.

This PR allows to have a _per request_ dataloader cache. 

Here are the updates contained in this PR:
* Add of a new `OnDemandDataLoaderRegistry` interface. This interface allows to provide a Spring Bean that can provide a new DataLoaderRegistry each time its `getNewDataLoaderRegistry()` method is called.
* Update of the `DefaultGraphQLInvocation` bean, so that when a `OnDemandDataLoaderRegistry` is provided, its `getNewDataLoaderRegistry()` method is called for each request invocation. This allows to have a _per_request_ dataloader cache
* Add of unit test to check that.
* README updated, with a documentation about this.

Of course, these updates are for both the webmvc and the webflux modules.

I also added the `javax.annotation-api` dependency, as it is necessary to compile on my java version.

Etienne