### PR TITLE
added GraphQLRootProvider

### DIFF
--- a/graphql-java-spring-webmvc/src/main/java/graphql/spring/web/servlet/GraphQLLocalContextProvider.java
+++ b/graphql-java-spring-webmvc/src/main/java/graphql/spring/web/servlet/GraphQLLocalContextProvider.java
@@ -1,0 +1,13 @@
+package graphql.spring.web.servlet;
+
+import java.util.function.Supplier;
+
+import graphql.PublicSpi;
+
+@PublicSpi
+public interface GraphQLLocalContextProvider extends Supplier<Object> {
+
+	@Override
+	public Object get();
+	
+}

--- a/graphql-java-spring-webmvc/src/main/java/graphql/spring/web/servlet/GraphQLRootProvider.java
+++ b/graphql-java-spring-webmvc/src/main/java/graphql/spring/web/servlet/GraphQLRootProvider.java
@@ -1,0 +1,13 @@
+package graphql.spring.web.servlet;
+
+import java.util.function.Supplier;
+
+import graphql.PublicSpi;
+
+@PublicSpi
+public interface GraphQLRootProvider extends Supplier<Object> {
+
+	@Override
+	public Object get();
+	
+}

--- a/graphql-java-spring-webmvc/src/main/java/graphql/spring/web/servlet/components/DefaultGraphQLInvocation.java
+++ b/graphql-java-spring-webmvc/src/main/java/graphql/spring/web/servlet/components/DefaultGraphQLInvocation.java
@@ -1,5 +1,12 @@
 package graphql.spring.web.servlet.components;
 
+import java.util.concurrent.CompletableFuture;
+
+import org.dataloader.DataLoaderRegistry;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.WebRequest;
+
 import graphql.ExecutionInput;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
@@ -7,12 +14,8 @@ import graphql.Internal;
 import graphql.spring.web.servlet.ExecutionInputCustomizer;
 import graphql.spring.web.servlet.GraphQLInvocation;
 import graphql.spring.web.servlet.GraphQLInvocationData;
-import org.dataloader.DataLoaderRegistry;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
-import org.springframework.web.context.request.WebRequest;
-
-import java.util.concurrent.CompletableFuture;
+import graphql.spring.web.servlet.GraphQLLocalContextProvider;
+import graphql.spring.web.servlet.GraphQLRootProvider;
 
 @Component
 @Internal
@@ -22,6 +25,12 @@ public class DefaultGraphQLInvocation implements GraphQLInvocation {
     GraphQL graphQL;
 
     @Autowired(required = false)
+    GraphQLRootProvider rootProvider;
+    
+    @Autowired(required = false)
+    GraphQLLocalContextProvider localContextProvider;
+
+    @Autowired(required = false)
     DataLoaderRegistry dataLoaderRegistry;
 
     @Autowired
@@ -29,11 +38,19 @@ public class DefaultGraphQLInvocation implements GraphQLInvocation {
 
     @Override
     public CompletableFuture<ExecutionResult> invoke(GraphQLInvocationData invocationData, WebRequest webRequest) {
-        ExecutionInput.Builder executionInputBuilder = ExecutionInput.newExecutionInput()
+    	ExecutionInput.Builder executionInputBuilder = ExecutionInput.newExecutionInput()
                 .query(invocationData.getQuery())
                 .operationName(invocationData.getOperationName())
                 .variables(invocationData.getVariables());
-        if (dataLoaderRegistry != null) {
+    	if (rootProvider != null) {
+    		Object root = rootProvider.get();
+    		executionInputBuilder.root(root);
+    	}
+    	if (localContextProvider != null) {
+    		Object localContext = localContextProvider.get();
+    		executionInputBuilder.localContext(localContext);
+    	}
+    	if (dataLoaderRegistry != null) {
             executionInputBuilder.dataLoaderRegistry(dataLoaderRegistry);
         }
         ExecutionInput executionInput = executionInputBuilder.build();


### PR DESCRIPTION
the optional bean GraphQLRootProvider allow to inject the root query object in ExecutionInput


